### PR TITLE
update azure resource names to match CAF resource abbreviations

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -10,7 +10,7 @@ resource "azurerm_subnet" "bastion_subnet" {
 resource "azurerm_public_ip" "bastion_public_ip" {
   count = var.bastion_enable ? 1 : 0
 
-  name                = "${local.deployment_id}-bastion-public-ip"
+  name                = "${local.deployment_id}-bas-pip"
   location            = local.location
   resource_group_name = local.rg.name
   allocation_method   = "Static"
@@ -22,7 +22,7 @@ resource "azurerm_public_ip" "bastion_public_ip" {
 resource "azurerm_bastion_host" "bastion" {
   count = var.bastion_enable ? 1 : 0
 
-  name                = "${local.deployment_id}-bastion"
+  name                = "${local.deployment_id}-bas"
   location            = local.location
   resource_group_name = local.rg.name
   copy_paste_enabled  = true

--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,7 @@ locals {
   # If user provides a location, use that. If not, use the location of the resource group provided.
   location = length(var.location) > 0 ? var.location : (local.rg.location)
 
-  lb_name                = "${local.deployment_id}-loadbalancer"
+  lb_name                = "${local.deployment_id}-lbi"
   lb_frontend_name       = "${local.lb_name}-frontend"
   lb_frontend_proxy_name = "${local.lb_name}-frontend-proxy"
   lb_direct_enable       = var.private_link_enable ? 0 : 1
@@ -32,10 +32,10 @@ locals {
 
   pcaps_storage_enable = var.lifecycle_pcaps_blob_days > 0
   pcaps_name           = lower("${local.deployment_id}-pcaps")
-  # Storage Account must be lowercase letters and numbers only.
+  # Storage Account must be lowercase letters and numbers only and must be < 25 characters.
   pcaps_sa_name = lower(join("", [substr(local.deployment_id, 0, 15), substr(random_uuid.pcap_uuid.result, 0, 4), "pcaps"]))
 
-  data_collection_name = "${local.deployment_id}-datacollect"
+  data_collection_name = "${local.deployment_id}-dcr"
 
   common_tags = {
     deployment_id = local.deployment_id

--- a/logging.tf
+++ b/logging.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_data_collection_rule" "vsensor_data_collection" {
-  name                = "${local.data_collection_name}-rule"
+  name                = local.data_collection_name
   location            = local.location
   resource_group_name = local.rg.name
   description         = "Collect metrics from vSensor Scale Set"
@@ -66,14 +66,14 @@ resource "azurerm_monitor_data_collection_rule" "vsensor_data_collection" {
 }
 
 resource "azurerm_monitor_data_collection_rule_association" "vsensor_data_collection_assoc" {
-  name                    = "${local.data_collection_name}-rule-assoc"
+  name                    = "${local.data_collection_name}-assoc"
   target_resource_id      = azurerm_linux_virtual_machine_scale_set.vsensor_vmss.id
   description             = "Association of data collection rule. Deleting this association will break the data collection for this virtual machine."
   data_collection_rule_id = azurerm_monitor_data_collection_rule.vsensor_data_collection.id
 }
 
 resource "azurerm_log_analytics_workspace" "vsensor_logs" {
-  name                            = "${local.deployment_id}-workspace"
+  name                            = "${local.deployment_id}-log"
   location                        = local.location
   resource_group_name             = local.rg.name
   sku                             = "PerGB2018"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
-data "azurerm_subscription" "subscription" {
-}
+data "azurerm_subscription" "subscription" {}
 
 # If an existing resource group has been provided, get it.
 data "azurerm_resource_group" "rg_existing" {

--- a/network.tf
+++ b/network.tf
@@ -17,7 +17,7 @@ data "azurerm_virtual_network" "vnet_existing" {
 
 resource "azurerm_public_ip" "natgw_public_ip" {
   count               = var.nat_gw_enable ? 1 : 0
-  name                = "${local.deployment_id}-natgw-public-ip"
+  name                = "${local.deployment_id}-ng-pip"
   location            = local.location
   resource_group_name = local.rg.name
   allocation_method   = "Static"
@@ -28,7 +28,7 @@ resource "azurerm_public_ip" "natgw_public_ip" {
 
 resource "azurerm_nat_gateway" "natgw" {
   count                   = var.nat_gw_enable ? 1 : 0
-  name                    = "${local.deployment_id}-natgw"
+  name                    = "${local.deployment_id}-ng"
   location                = local.location
   resource_group_name     = local.rg.name
   sku_name                = "Standard"

--- a/pcaps.tf
+++ b/pcaps.tf
@@ -1,7 +1,6 @@
 # Used in locals.tf to rename storage account UUID since you can't
 # recreate a new storage account with the same name as an old one.
-resource "random_uuid" "pcap_uuid" {
-}
+resource "random_uuid" "pcap_uuid" {}
 
 # Ignore network_rules being missing causing critical, it is separate below
 # It needs to be separate due to a cycle with virtual_network_subnet_ids
@@ -68,11 +67,11 @@ resource "azurerm_storage_management_policy" "pcaps_storage_policy" {
 resource "azurerm_subnet_service_endpoint_storage_policy" "pcaps_service_endpoint_policy" {
   count = local.pcaps_storage_enable ? 1 : 0
 
-  name                = "${local.pcaps_name}-service-endpoint"
+  name                = "${local.pcaps_name}-se"
   location            = local.location
   resource_group_name = local.rg.name
   definition {
-    name              = "${local.pcaps_name}-service-endpoint-definition"
+    name              = "${local.pcaps_name}-se-definition"
     service           = "Microsoft.Storage"
     service_resources = [azurerm_storage_account.pcaps_storage_account[0].id]
   }

--- a/private_link.tf
+++ b/private_link.tf
@@ -1,7 +1,7 @@
 resource "azurerm_private_link_service" "ossensor_private_link" {
   count = var.private_link_enable ? 1 : 0
 
-  name                = "${local.deployment_id}-privatelink"
+  name                = "${local.deployment_id}-pl"
   location            = local.location
   resource_group_name = local.rg.name
   nat_ip_configuration {


### PR DESCRIPTION
This pull request includes several changes to resource suffixes to match the suggested resource abbreviations of the [Azure Cloud Adoption Framework](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations). This could be beneficial for this module since most of the customers follow these recommendations to have a consistent naming.

### Compliance with Naming Conventions:

* `bastion.tf`: Adjusted the names of the bastion host and bastion public IP resources.  
(`azurerm_public_ip.bastion_public_ip`, `azurerm_bastion_host.bastion`)

* `locals.tf`: Adjusted the names of the load balancer and data collection rule.  
(`local.lb_name`, `local.data_collection_name`) 

* `logging.tf`: Adjusted the data collection rule and its association names as well as the log analytics workspace. 
 (`azurerm_monitor_data_collection_rule.vsensor_data_collection`, `azurerm_monitor_data_collection_rule_association.vsensor_data_collection_assoc`, `azurerm_log_analytics_workspace.vsensor_logs`)

* `network.tf`: Adjusted the names of the NAT gateway and NAT gateway public IP resources. 
 (`azurerm_public_ip.natgw_public_ip`, `azurerm_nat_gateway.natgw`) 

* `pcaps.tf`: Adjusted the name of the service endpoint policy resource. 
 (`azurerm_subnet_service_endpoint_storage_policy.pcaps_service_endpoint_policy`)

* `private_link.tf`: Adjusted the name of the private link service resource.  (`azurerm_private_link_service.ossensor_private_link`)

### Minor Cleanups:

* `main.tf`: Simplified the azurerm_subscription data block.  
(`data.azurerm_subscription.subscription`)

* `pcaps.tf`: Simplified the random_uuid resource block.  
(`random_uuid.pcap_uuid`)
